### PR TITLE
ci: pass credentials to release process

### DIFF
--- a/.github/workflows/semantic-release-dry-run.yml
+++ b/.github/workflows/semantic-release-dry-run.yml
@@ -1,6 +1,7 @@
 ---
 name: Release Test
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:

--- a/.github/workflows/semantic-release-dry-run.yml
+++ b/.github/workflows/semantic-release-dry-run.yml
@@ -1,7 +1,6 @@
 ---
 name: Release Test
 
-# yamllint disable-line rule:truthy
 on:
   push:
     branches:
@@ -13,12 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout dry branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           ref: release-dry-run
 
+      - name: Set up JDK 11
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           node-version: "lts/*"
 
@@ -28,4 +34,8 @@ jobs:
       - name: Dry run
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GH_TOKEN }}
+          SERVER_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          SERVER_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: unset GITHUB_ACTIONS && npx --prefix .release/ semantic-release --dry-run --no-ci --debug

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,6 +1,7 @@
 ---
 name: Release
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,7 +1,6 @@
 ---
 name: Release
 
-# yamllint disable-line rule:truthy
 on:
   push:
     branches:
@@ -13,16 +12,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
           node-version: "lts/*"
+
       - name: Install dependencies
         run: npm --prefix .release/ ci
+
       - name: Release
         run: npx --prefix .release/ semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GH_TOKEN }}
+          SERVER_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          SERVER_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
The release process for Maven artifacts fails, if the credentials are missing. Authentication is required to publish them.