### PR TITLE
feat: add configuration option `additionalPackagesToIgnore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@
 This project contains a stacktrace filter for the Log4j2 logging system. It can be included in a [`JsonTemplateLayout`](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html).
 
 The plugin reduces the stacktrace by filtering classes which are not of any interest. It has a built-in list of packages to exclude
-from the stacktrace.
+from the stacktrace. Additional packages can be configured in the `log4j2.xml` file. Find the full blown example below.
+
+This plugin was built on top of the work of the Apache Log4j team and takanuva15, who described the plugin in a
+[Stackoverflow article](https://stackoverflow.com/questions/70614495/is-there-a-way-to-override-the-exceptionresolver-of-jsontemplatelayout-of-log4j2/77143208#77143208).
+We replaced the main logic completely. 
 
 # Output
 
@@ -54,7 +58,7 @@ Include the following artifact to your project which contains the `log4j2.xml` c
     <Appenders>
         <Console name="console-datadog" target="SYSTEM_OUT">
             <JsonTemplateLayout eventTemplateUri="classpath:JsonLayout.json" maxStringLength="32768"  stackTraceEnabled="false">
-                <EventTemplateAdditionalField key="error" format="JSON" value='{"$resolver": "filteredStacktraceException"}'/>
+                <EventTemplateAdditionalField key="error" format="JSON" value='{"$resolver": "filteredStacktraceException"}, "additionalPackagesToIgnore": ["com.hlag.logging.log4j2."]}' />
             </JsonTemplateLayout>
         </Console>
     </Appenders>
@@ -66,3 +70,8 @@ Include the following artifact to your project which contains the `log4j2.xml` c
     </Loggers>
 </Configuration>
 ```
+
+## additionalPackagesToIgnore
+
+Use this parameter to add other packages to the built-in list. These packages are ignored too. Especially useful uf you have to
+include company internal frameworks, but you don't want to see them in the stacktrace. 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ from the stacktrace. Additional packages can be configured in the `log4j2.xml` f
 
 This plugin was built on top of the work of the Apache Log4j team and takanuva15, who described the plugin in a
 [Stackoverflow article](https://stackoverflow.com/questions/70614495/is-there-a-way-to-override-the-exceptionresolver-of-jsontemplatelayout-of-log4j2/77143208#77143208).
-We replaced the main logic completely. 
+We replaced the main logic completely.
 
 # Output
 
@@ -51,6 +51,8 @@ Include the following artifact to your project which contains the `log4j2.xml` c
 
 ## Log4j2 Configuration
 
+<!-- no line breaks in Json please -->
+<!-- markdownlint-disable line-length -->
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="INFO">
@@ -58,7 +60,8 @@ Include the following artifact to your project which contains the `log4j2.xml` c
     <Appenders>
         <Console name="console-datadog" target="SYSTEM_OUT">
             <JsonTemplateLayout eventTemplateUri="classpath:JsonLayout.json" maxStringLength="32768"  stackTraceEnabled="false">
-                <EventTemplateAdditionalField key="error" format="JSON" value='{"$resolver": "filteredStacktraceException"}, "additionalPackagesToIgnore": ["com.hlag.logging.log4j2."]}' />
+                <EventTemplateAdditionalField key="error" format="JSON"
+                                              value='{"$resolver": "filteredStacktraceException"}, "additionalPackagesToIgnore": ["com.hlag.logging.log4j2."]}' />
             </JsonTemplateLayout>
         </Console>
     </Appenders>
@@ -70,8 +73,9 @@ Include the following artifact to your project which contains the `log4j2.xml` c
     </Loggers>
 </Configuration>
 ```
+<!-- markdownlint-enable line-length -->
 
 ## additionalPackagesToIgnore
 
 Use this parameter to add other packages to the built-in list. These packages are ignored too. Especially useful uf you have to
-include company internal frameworks, but you don't want to see them in the stacktrace. 
+include company internal frameworks, but you don't want to see them in the stacktrace.

--- a/pom.xml
+++ b/pom.xml
@@ -185,12 +185,6 @@
             <artifactId>log4j-layout-template-json</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>33.1.0-jre</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Lombok for code generation only-->
         <dependency>

--- a/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
+++ b/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
@@ -10,6 +10,8 @@ import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Defines a custom resolver to remove stacktrace lines that are irrelevant.
@@ -19,26 +21,24 @@ import java.util.List;
  */
 class FilteredStacktraceExceptionResolver implements EventResolver {
     private static List<String> packagesToRemoveFromStacktrace = Arrays.asList(
-            "com.ibm.ejs",
-            "com.ibm.tx",
-            "com.ibm.ws",
-            "java.lang",
-            "java.security",
-            "java.util.concurrent",
-            "javax.servlet",
-            "jdk.internal",
-            "org.apache.cxf",
-            "org.hibernate.validator.cdi",
-            "org.jboss.weld");
+            "com.ibm.ejs.",
+            "com.ibm.tx.",
+            "com.ibm.ws.",
+            "java.lang.",
+            "java.security.",
+            "java.util.concurrent.",
+            "javax.servlet.",
+            "jdk.internal.",
+            "org.apache.cxf.",
+            "org.hibernate.validator.cdi.",
+            "org.jboss.weld.");
     private final TemplateResolver<Throwable> internalResolver;
 
     FilteredStacktraceExceptionResolver(EventResolverContext context, TemplateResolverConfig config) {
-        this.internalResolver = new FilteredStacktraceStackTraceJsonResolver(context, packagesToRemoveFromStacktrace);
-    }
+        List<String> additionalPackagesToIgnore = config.getList("additionalPackagesToIgnore", String.class);
 
-    @VisibleForTesting
-    static void setPackagesToRemoveFromStacktrace(List<String> packagesToRemoveFromStacktrace) {
-        FilteredStacktraceExceptionResolver.packagesToRemoveFromStacktrace = packagesToRemoveFromStacktrace;
+        this.internalResolver = new FilteredStacktraceStackTraceJsonResolver(context, Stream.concat(packagesToRemoveFromStacktrace.stream(), additionalPackagesToIgnore.stream())
+                .collect(Collectors.toList()));
     }
 
     @Override

--- a/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
+++ b/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
@@ -1,6 +1,5 @@
 package com.hlag.logging.log4j2;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.layout.template.json.resolver.EventResolver;
 import org.apache.logging.log4j.layout.template.json.resolver.EventResolverContext;

--- a/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverUnitTest.java
+++ b/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverUnitTest.java
@@ -2,6 +2,7 @@ package com.hlag.logging.log4j2;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.layout.template.json.resolver.EventResolverContext;
+import org.apache.logging.log4j.layout.template.json.resolver.TemplateResolverConfig;
 import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
 import org.apache.logging.log4j.layout.template.json.util.QueueingRecyclerFactory;
 import org.assertj.core.api.Assertions;
@@ -15,7 +16,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.LinkedList;
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class FilteredStacktraceStackTraceJsonResolverUnitTest {
@@ -25,16 +25,19 @@ class FilteredStacktraceStackTraceJsonResolverUnitTest {
 
     @Mock
     private EventResolverContext mockedEventResolverContext;
+    @Mock
+    private TemplateResolverConfig mockedConfig;
 
     @BeforeEach
     void setUp() {
         Mockito.when(mockedEventResolverContext.getRecyclerFactory()).thenReturn(new QueueingRecyclerFactory(LinkedList::new));
         Mockito.when(mockedEventResolverContext.getMaxStringByteCount()).thenReturn(60000);
 
+        Mockito.when(mockedConfig.getList(Mockito.eq("additionalPackagesToIgnore"), Mockito.eq(String.class))).thenReturn(Arrays.asList("com.hlag.logging.log4j2"));
+
         jsonWriter = JsonWriter.newBuilder().setMaxStringLength(60000).setTruncatedStringSuffix("...").build();
 
-        FilteredStacktraceExceptionResolver.setPackagesToRemoveFromStacktrace(Arrays.asList("com.hlag.logging.log4j2"));
-        filteredStacktraceExceptionResolver = new FilteredStacktraceExceptionResolver(mockedEventResolverContext, null);
+        filteredStacktraceExceptionResolver = new FilteredStacktraceExceptionResolver(mockedEventResolverContext, mockedConfig);
     }
 
     @Test
@@ -70,7 +73,7 @@ class FilteredStacktraceStackTraceJsonResolverUnitTest {
 
         JSONObject actualLogOutput = new JSONObject(actualStringOutput);
 
-        Assertions.assertThat(actualLogOutput.get("totalFilteredElements")).isEqualTo(2);
+        Assertions.assertThat(actualLogOutput.get("totalFilteredElements")).isEqualTo(6);
     }
 
     @Test

--- a/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverUnitTest.java
+++ b/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverUnitTest.java
@@ -33,6 +33,7 @@ class FilteredStacktraceStackTraceJsonResolverUnitTest {
         Mockito.when(mockedEventResolverContext.getRecyclerFactory()).thenReturn(new QueueingRecyclerFactory(LinkedList::new));
         Mockito.when(mockedEventResolverContext.getMaxStringByteCount()).thenReturn(60000);
 
+        // this ensures that the internal mechanism of adding packages is working
         Mockito.when(mockedConfig.getList(Mockito.eq("additionalPackagesToIgnore"), Mockito.eq(String.class))).thenReturn(Arrays.asList("com.hlag.logging.log4j2"));
 
         jsonWriter = JsonWriter.newBuilder().setMaxStringLength(60000).setTruncatedStringSuffix("...").build();

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -3,7 +3,8 @@
     <Appenders>
         <Console name="console" target="SYSTEM_OUT">
             <JsonTemplateLayout eventTemplateUri="classpath:JsonLayout.json" maxStringLength="32768" stackTraceEnabled="false">
-                <EventTemplateAdditionalField key="error" format="JSON" value='{"$resolver": "filteredStacktraceException"}'/>
+                <EventTemplateAdditionalField key="error" format="JSON"
+                                              value='{"$resolver": "filteredStacktraceException", "additionalPackagesToIgnore": ["com.hlag.logging.log4j2"]}' />
             </JsonTemplateLayout>
         </Console>
     </Appenders>


### PR DESCRIPTION
# Description

Adds an option `additionalPackagesToIgnore` to add packages to the built-in list. Useful to ignore some more package of your own choice.

`<EventTemplateAdditionalField key="error" format="JSON" value='{"$resolver": "filteredStacktraceException"}, "additionalPackagesToIgnore": ["com.hlag.logging.log4j2."]}' />`

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
