### PR TITLE
feat: ignore `com.ibm.websphere.jaxrs.` packages

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -13,7 +13,8 @@
     "javadocs",
     "servlet",
     "sonatype",
-    "stackoverflow"
+    "stackoverflow",
+    "websphere"
   ],
   "ignoreWords": [
     "amannn",
@@ -24,6 +25,7 @@
     "hapag",
     "hmarr",
     "ibiqlik",
+    "jaxrs",
     "kayman",
     "ludeeus",
     "markdownlint",

--- a/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
+++ b/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
@@ -21,6 +21,7 @@ class FilteredStacktraceExceptionResolver implements EventResolver {
     private static List<String> packagesToRemoveFromStacktrace = Arrays.asList(
             "com.ibm.ejs",
             "com.ibm.tx",
+            "com.ibm.websphere.jaxrs.",
             "com.ibm.ws",
             "java.lang",
             "java.security",


### PR DESCRIPTION
# Description

Adds `com.ibm.websphere.jaxrs.` to the built-in ignore list as these packages do not provide any insights.
