### PR TITLE
feat: add `whitelistPackages` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- First line should be an H1: Badges on top please! -->
 <!-- markdownlint-disable first-line-h1 -->
-[![Actions](https://github.com/Hapag-Lloyd/log4j2-filtered-stacktrace-plugin/workflows/semantic-release/badge.svg)](https://github.com/Hapag-Lloyd/log4j2-filtered-stacktrace-plugin/actions)
+[![Actions](https://github.com/Hapag-Lloyd/log4j2-filtered-stacktrace-plugin/workflows/Release/badge.svg)](https://github.com/Hapag-Lloyd/log4j2-filtered-stacktrace-plugin/actions)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.hlag.logging/log4j2-stacktrace-filter/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.hlag.logging/log4j2-stacktrace-filter-plugin)
 <!-- markdownlint-enable first-line-h1 -->
 
@@ -20,7 +20,7 @@ We replaced the main logic completely.
 Adding the filter to the logging configuration with `<EventTemplateAdditionalField key="error" format="JSON" value='{"$resolver": "filteredStacktraceException"}'/>`
 produces the following Json object in the log stream:
 
-<!-- no line breaks in Json please -->
+<!-- no line breaks in Json please, we are fine with long lines here -->
 <!-- markdownlint-disable line-length -->
 ```json
 "error": {
@@ -41,24 +41,26 @@ produces the following Json object in the log stream:
 Include the following artifact to your project which contains the `log4j2.xml` configuration file. Make sure to use the newest version.
 
 ```xml
+<!-- pom.xml -->
 <dependency>
     <groupId>com.hlag.logging</groupId>
     <artifactId>log4j2-stacktrace-filter</artifactId>
     <!-- make sure to use the newest version -->
-    <version>1.0.0</version>
+    <version>1.3.0</version>
 </dependency>
 ```
 
 ## Log4j2 Configuration
 
-<!-- no line breaks in Json please -->
+<!-- no line breaks in Json please, we are fine with long lines here -->
 <!-- markdownlint-disable line-length -->
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- log4j2.xml -->
 <Configuration status="INFO">
 
     <Appenders>
-        <Console name="console-datadog" target="SYSTEM_OUT">
+        <Console name="console" target="SYSTEM_OUT">
             <JsonTemplateLayout eventTemplateUri="classpath:JsonLayout.json" maxStringLength="32768"  stackTraceEnabled="false">
                 <EventTemplateAdditionalField key="error" format="JSON"
                                               value='{"$resolver": "filteredStacktraceException"}, "additionalPackagesToIgnore": ["com.hlag.logging.log4j2."]}' />
@@ -79,3 +81,10 @@ Include the following artifact to your project which contains the `log4j2.xml` c
 
 Use this parameter to add other packages to the built-in list. These packages are ignored too. Especially useful if you have to
 include company internal frameworks, but you don't want to see them in the stacktrace.
+
+Makes no sense to specify `whitelistedPackages` in addition to this parameter.
+
+### whitelistPackages
+
+Use this parameter to add packages which should not be ignored. This is useful if you want to ignore all packages except a few. The
+built-in list is ignored in this case as well as `additionalPackagesToIgnore`.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Include the following artifact to your project which contains the `log4j2.xml` c
 ```
 <!-- markdownlint-enable line-length -->
 
-## additionalPackagesToIgnore
+### additionalPackagesToIgnore
 
-Use this parameter to add other packages to the built-in list. These packages are ignored too. Especially useful uf you have to
+Use this parameter to add other packages to the built-in list. These packages are ignored too. Especially useful if you have to
 include company internal frameworks, but you don't want to see them in the stacktrace.

--- a/README.md
+++ b/README.md
@@ -86,5 +86,6 @@ Makes no sense to specify `whitelistedPackages` in addition to this parameter.
 
 ### whitelistPackages
 
-Use this parameter to add packages which should not be ignored. This is useful if you want to ignore all packages except a few. The
-built-in list is ignored in this case as well as `additionalPackagesToIgnore`.
+Use this parameter to define packages which should remain when filtering a stack trace. Every other package is removed from the
+stacktrace. The built-in list of packages to filter as well as the `additionalPackagesToIgnore` parameter have no effect when
+`whitelistPackages` exists.

--- a/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
+++ b/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
@@ -36,10 +36,11 @@ class FilteredStacktraceExceptionResolver implements EventResolver {
     private final TemplateResolver<Throwable> internalResolver;
 
     FilteredStacktraceExceptionResolver(EventResolverContext context, TemplateResolverConfig config) {
+        List<String> whitelistPackages = config.getList("whitelistPackages", String.class);
         List<String> additionalPackagesToIgnore = config.getList("additionalPackagesToIgnore", String.class);
 
         this.internalResolver = new FilteredStacktraceStackTraceJsonResolver(context, Stream.concat(packagesToRemoveFromStacktrace.stream(), additionalPackagesToIgnore.stream())
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList()), whitelistPackages);
     }
 
     @Override

--- a/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolverUnitTest.java
+++ b/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolverUnitTest.java
@@ -37,7 +37,7 @@ class FilteredStacktraceExceptionResolverUnitTest {
         Mockito.lenient().when(mockedEventResolverContext.getRecyclerFactory()).thenReturn(new QueueingRecyclerFactory(LinkedList::new));
         Mockito.lenient().when(mockedEventResolverContext.getMaxStringByteCount()).thenReturn(10000);
 
-        Mockito.when(mockedConfig.getList(Mockito.eq("additionalPackagesToIgnore"), Mockito.eq(String.class))).thenReturn(PACKAGE_TO_REMOVE_FROM_STACKTRACE);
+        Mockito.when(mockedConfig.getList("additionalPackagesToIgnore", String.class)).thenReturn(PACKAGE_TO_REMOVE_FROM_STACKTRACE);
 
         jsonWriter = JsonWriter.newBuilder().setMaxStringLength(10000).setTruncatedStringSuffix("...").build();
 

--- a/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolverUnitTest.java
+++ b/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolverUnitTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -38,6 +39,7 @@ class FilteredStacktraceExceptionResolverUnitTest {
         Mockito.lenient().when(mockedEventResolverContext.getMaxStringByteCount()).thenReturn(10000);
 
         Mockito.when(mockedConfig.getList("additionalPackagesToIgnore", String.class)).thenReturn(PACKAGE_TO_REMOVE_FROM_STACKTRACE);
+        Mockito.when(mockedConfig.getList("whitelistPackages", String.class)).thenReturn(new ArrayList<>());
 
         jsonWriter = JsonWriter.newBuilder().setMaxStringLength(10000).setTruncatedStringSuffix("...").build();
 

--- a/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverUnitTest.java
+++ b/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverUnitTest.java
@@ -14,7 +14,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,7 +35,8 @@ class FilteredStacktraceStackTraceJsonResolverUnitTest {
         Mockito.when(mockedEventResolverContext.getMaxStringByteCount()).thenReturn(60000);
 
         // this ensures that the internal mechanism of adding packages is working
-        Mockito.when(mockedConfig.getList(Mockito.eq("additionalPackagesToIgnore"), Mockito.eq(String.class))).thenReturn(Arrays.asList("com.hlag.logging.log4j2"));
+        Mockito.when(mockedConfig.getList("additionalPackagesToIgnore", String.class)).thenReturn(Collections.singletonList("com.hlag.logging.log4j2"));
+        Mockito.when(mockedConfig.getList("whitelistPackages", String.class)).thenReturn(new ArrayList<>());
 
         jsonWriter = JsonWriter.newBuilder().setMaxStringLength(60000).setTruncatedStringSuffix("...").build();
 
@@ -141,12 +143,9 @@ class FilteredStacktraceStackTraceJsonResolverUnitTest {
 
     private Exception createExceptionWithStacktrace() {
         try {
-            int a = 0 / 0;
+            throw new ArithmeticException("/ by zero");
         } catch (Exception e) {
             return e;
         }
-
-        // never reached
-        return new RuntimeException();
     }
 }

--- a/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverWhitelistUnitTest.java
+++ b/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverWhitelistUnitTest.java
@@ -1,0 +1,69 @@
+package com.hlag.logging.log4j2;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.layout.template.json.resolver.EventResolverContext;
+import org.apache.logging.log4j.layout.template.json.resolver.TemplateResolverConfig;
+import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
+import org.apache.logging.log4j.layout.template.json.util.QueueingRecyclerFactory;
+import org.assertj.core.api.Assertions;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.LinkedList;
+
+@ExtendWith(MockitoExtension.class)
+class FilteredStacktraceStackTraceJsonResolverWhitelistUnitTest {
+    private FilteredStacktraceExceptionResolver filteredStacktraceExceptionResolver;
+
+    private JsonWriter jsonWriter;
+
+    @Mock
+    private EventResolverContext mockedEventResolverContext;
+    @Mock
+    private TemplateResolverConfig mockedConfig;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.when(mockedEventResolverContext.getRecyclerFactory()).thenReturn(new QueueingRecyclerFactory(LinkedList::new));
+        Mockito.when(mockedEventResolverContext.getMaxStringByteCount()).thenReturn(60000);
+
+        // sets the package whitelist
+        Mockito.when(mockedConfig.getList("whitelistPackages", String.class)).thenReturn(Collections.singletonList("com.hlag.logging.log4j2"));
+
+        jsonWriter = JsonWriter.newBuilder().setMaxStringLength(60000).setTruncatedStringSuffix("...").build();
+
+        filteredStacktraceExceptionResolver = new FilteredStacktraceExceptionResolver(mockedEventResolverContext, mockedConfig);
+    }
+
+    @Test
+    void shouldHaveWhitelistedPackagesOnly_whenResolve_givenThrowable() {
+        LogEvent givenLogEvent = TestLogEvent.builder().thrown(wrappedThrowable()).build();
+
+        filteredStacktraceExceptionResolver.resolve(givenLogEvent, jsonWriter);
+        String actualStringOutput = jsonWriter.getStringBuilder().toString();
+
+        JSONObject actualLogOutput = new JSONObject(actualStringOutput);
+
+        Assertions.assertThat(actualLogOutput.get("stack").toString().split(System.lineSeparator()))
+                .filteredOn(line -> line.startsWith("\tat "))
+                .allSatisfy(line -> Assertions.assertThat(line).startsWith("\tat com.hlag.logging.log4j2."));
+    }
+
+    private Throwable wrappedThrowable() {
+        return new RuntimeException(createExceptionWithStacktrace());
+    }
+
+    private Exception createExceptionWithStacktrace() {
+        try {
+            throw new ArithmeticException("/ by zero");
+        } catch (Exception e) {
+            return e;
+        }
+    }
+}

--- a/src/test/java/com/hlag/logging/log4j2/LoggerIntegrationTest.java
+++ b/src/test/java/com/hlag/logging/log4j2/LoggerIntegrationTest.java
@@ -22,6 +22,6 @@ class LoggerIntegrationTest {
         }
     }
     private void throwArithmeticException() {
-        float a = 0 / 0;
+        throw new ArithmeticException("/ by zero");
     }
 }


### PR DESCRIPTION
# Description

This PR adds a `whitelistPackages` configuration option to the `FilteredStacktraceExceptionResolver`. Given this configuration, the mentioned packages will always be shown in the stacktrace, while all others won't. `additionalPackagesToIgnore` are ignored as well as the built-in package list.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
