### PR TITLE
fix: remove bug when additionalPackagesToIgnore is not set

### DIFF
--- a/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
+++ b/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
@@ -39,6 +39,10 @@ class FilteredStacktraceExceptionResolver implements EventResolver {
         List<String> whitelistPackages = config.getList("whitelistPackages", String.class);
         List<String> additionalPackagesToIgnore = config.getList("additionalPackagesToIgnore", String.class);
 
+        if (additionalPackagesToIgnore == null) {
+            additionalPackagesToIgnore = Arrays.asList();
+        }
+
         this.internalResolver = new FilteredStacktraceStackTraceJsonResolver(context, Stream.concat(packagesToRemoveFromStacktrace.stream(), additionalPackagesToIgnore.stream())
                 .collect(Collectors.toList()), whitelistPackages);
     }

--- a/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
+++ b/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolver.java
@@ -43,6 +43,10 @@ class FilteredStacktraceExceptionResolver implements EventResolver {
             additionalPackagesToIgnore = Arrays.asList();
         }
 
+        if (whitelistPackages == null) {
+            whitelistPackages = Arrays.asList();
+        }
+
         this.internalResolver = new FilteredStacktraceStackTraceJsonResolver(context, Stream.concat(packagesToRemoveFromStacktrace.stream(), additionalPackagesToIgnore.stream())
                 .collect(Collectors.toList()), whitelistPackages);
     }

--- a/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolver.java
+++ b/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolver.java
@@ -29,6 +29,10 @@ class FilteredStacktraceStackTraceJsonResolver implements TemplateResolver<Throw
         final Supplier<TruncatingBufferedPrintWriter> writerSupplier = () -> TruncatingBufferedPrintWriter.ofCapacity(context.getMaxStringByteCount());
         final RecyclerFactory recyclerFactory = context.getRecyclerFactory();
 
+        if (whitelistPackages == null) {
+            throw new IllegalArgumentException();
+        }
+
         this.destWriterRecycler = recyclerFactory.create(writerSupplier, TruncatingBufferedPrintWriter::close);
         this.packagePrefixesToFilter = packagePrefixesToFilter;
         this.whitelistPackages = whitelistPackages;

--- a/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolverUnitTest.java
+++ b/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceExceptionResolverUnitTest.java
@@ -47,6 +47,22 @@ class FilteredStacktraceExceptionResolverUnitTest {
     }
 
     @Test
+    void shouldBeAbleToCreateInstance_whenConstructor_givenAdditionalPackagesIsNull() {
+        Mockito.when(mockedConfig.getList("additionalPackagesToIgnore", String.class)).thenReturn(null);
+
+        NullPointerException e = Assertions.catchThrowableOfType(() -> new FilteredStacktraceExceptionResolver(mockedEventResolverContext, mockedConfig), NullPointerException.class);
+        Assertions.assertThat(e).isNull();
+    }
+
+    @Test
+    void shouldBeAbleToCreateInstance_whenConstructor_givenWhitelistIsNull() {
+        Mockito.when(mockedConfig.getList("whitelistPackages", String.class)).thenReturn(null);
+
+        NullPointerException e = Assertions.catchThrowableOfType(() -> new FilteredStacktraceExceptionResolver(mockedEventResolverContext, mockedConfig), NullPointerException.class);
+        Assertions.assertThat(e).isNull();
+    }
+
+    @Test
     void shouldReturnTrue_whenIsResolve_givenExceptionInLogEvent() {
         LogEvent givenLogEvent = TestLogEvent.builder().thrown(new RuntimeException()).build();
 


### PR DESCRIPTION
# Description

When additionalPackagesToIgnore is not set, a NPE is thrown because the return value of config.getList is null

# Verification

This pr adds the non-null check. If the parameter is null, a new array is created and the variable is set to it.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
