### PR TITLE
fix: write valid json when logging stack traces

### DIFF
--- a/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolver.java
+++ b/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolver.java
@@ -90,7 +90,6 @@ class FilteredStacktraceStackTraceJsonResolver implements TemplateResolver<Throw
         jsonAttributes.put("name", throwable.getClass().getName());
 
         jsonWriter.writeObject(jsonAttributes);
-        jsonWriter.writeObjectEnd();
     }
 
     private List<Cause> flattenAndFilterAllCauses(Throwable throwable) {

--- a/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverUnitTest.java
+++ b/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverUnitTest.java
@@ -68,6 +68,17 @@ class FilteredStacktraceStackTraceJsonResolverUnitTest {
     }
 
     @Test
+    void shouldHaveCorrectNumberOfCurlyBraces_whenResolve() {
+        LogEvent givenLogEvent = TestLogEvent.builder().thrown(createExceptionWithStacktrace()).build();
+
+        filteredStacktraceExceptionResolver.resolve(givenLogEvent, jsonWriter);
+        String actualStringOutput = jsonWriter.getStringBuilder().toString();
+
+        Assertions.assertThat(actualStringOutput).containsOnlyOnce("{");
+        Assertions.assertThat(actualStringOutput).containsOnlyOnce("}");
+    }
+
+    @Test
     void shouldHaveTotalFilteredElementsAttribute_whenResolve() {
         LogEvent givenLogEvent = TestLogEvent.builder().thrown(createExceptionWithStacktrace()).build();
 


### PR DESCRIPTION
# Description

When writing exceptions to json, at the end of the already valid json, another closing bracket was written. This causes the following json to become invalid. This PR fixes this behavior

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation