### PR TITLE
ci: set up team as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
-# maintainers of the project
-*   @kayman-mk @PascalFrenz
+*       @hapag-lloyd/quotation-and-contract-management
+
+# license file shouldn't be changed and needs to be reviewed by lawyers
+LICENSE @hapag-lloyd/organization-defaults


### PR DESCRIPTION
Description

Use the QCM team as code-owner instead of single members. Allows our Bot to automatically confirm pull requests.