### PR TITLE
fix: add cause message to "Caused by" lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ produces the following Json object in the log stream:
 <!-- markdownlint-disable line-length -->
 ```json
 "error": {
-  "stack": "java.lang.RuntimeException: java.lang.ArithmeticException: / by zero\r\n\tat com.hlag.logging.log4j2.LoggerIntegrationTest.wrapException(LoggerIntegrationTest.java:21)\r\n\tat com.hlag.logging.log4j2.LoggerIntegrationTest.logException(LoggerIntegrationTest.java:11)\r\n\t[suppressed 70 lines]\r\ncaused by java.lang.ArithmeticException\r\n\tat com.hlag.logging.log4j2.LoggerIntegrationTest.throwArithmeticException(LoggerIntegrationTest.java:25)\r\n\tat com.hlag.logging.log4j2.LoggerIntegrationTest.wrapException(LoggerIntegrationTest.java:19)\r\n\tat com.hlag.logging.log4j2.LoggerIntegrationTest.logException(LoggerIntegrationTest.java:11)\r\n\t[suppressed 70 lines]",
+  "stack": "java.lang.RuntimeException: java.lang.ArithmeticException: / by zero\r\n\tat com.hlag.logging.log4j2.LoggerIntegrationTest.wrapException(LoggerIntegrationTest.java:21)\r\n\tat com.hlag.logging.log4j2.LoggerIntegrationTest.logException(LoggerIntegrationTest.java:11)\r\n\t[suppressed 70 lines]\r\nCaused by java.lang.ArithmeticException: / by zero\r\n\tat com.hlag.logging.log4j2.LoggerIntegrationTest.throwArithmeticException(LoggerIntegrationTest.java:25)\r\n\tat com.hlag.logging.log4j2.LoggerIntegrationTest.wrapException(LoggerIntegrationTest.java:19)\r\n\tat com.hlag.logging.log4j2.LoggerIntegrationTest.logException(LoggerIntegrationTest.java:11)\r\n\t[suppressed 70 lines]",
   "name": "java.lang.RuntimeException",
   "message": "java.lang.ArithmeticException: / by zero",
   "totalFilteredElements": 140

--- a/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolver.java
+++ b/src/main/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolver.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 /**
- * Holds the logic on how to delete irrelevant stacktrace lines and formats the stacktrace showing all "caused by".
+ * Holds the logic on how to delete irrelevant stacktrace lines and formats the stacktrace showing all "Caused by".
  * <p>
  * Originally based on <a href="https://stackoverflow.com/questions/70614495/is-there-a-way-to-override-the-exceptionresolver-of-jsontemplatelayout-of-log4j2/77143208#77143208">Stackoverflow</a>
  * but works totally different now.
@@ -51,9 +51,9 @@ class FilteredStacktraceStackTraceJsonResolver implements TemplateResolver<Throw
 
             for (Cause cause : allCauses) {
                 if (!firstCause) {
-                    // write a "caused by"
+                    // write a "Caused by" including cause message, like Java's native stack exporter.
                     stacktraceAsStringWriter.append(System.lineSeparator());
-                    stacktraceAsStringWriter.append(String.format("caused by %s", cause.throwable.getClass().getName()));
+                    stacktraceAsStringWriter.append(String.format("Caused by %s: %s", cause.throwable.getClass().getName(), cause.throwable.getMessage()));
                 }
 
                 int currentFilteredLines = 0;

--- a/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverUnitTest.java
+++ b/src/test/java/com/hlag/logging/log4j2/FilteredStacktraceStackTraceJsonResolverUnitTest.java
@@ -114,7 +114,7 @@ class FilteredStacktraceStackTraceJsonResolverUnitTest {
         JSONObject actualLogOutput = new JSONObject(actualStringOutput);
 
         Assertions.assertThat(actualLogOutput.get("stack").toString().split(System.lineSeparator()))
-                .filteredOn(line -> line.equals("caused by java.lang.ArithmeticException"))
+                .filteredOn(line -> line.equals("Caused by java.lang.ArithmeticException: / by zero"))
                 .hasSize(1);
     }
 
@@ -144,7 +144,7 @@ class FilteredStacktraceStackTraceJsonResolverUnitTest {
         // trying to ignore all non stacktrace lines
         Assertions.assertThat(actualLogOutput.get("stack").toString().split(System.lineSeparator()))
                 .filteredOn(line -> !line.startsWith("\t[suppressed"))
-                .filteredOn(line -> !line.startsWith("caused by"))
+                .filteredOn(line -> !line.startsWith("Caused by"))
                 .filteredOn(line -> !line.startsWith("java.lang.RuntimeException"))
                 .allMatch(line -> line.startsWith("\tat "));
     }


### PR DESCRIPTION
# Description

We use the filtered stacktrace plugin to log filtered stack traces without a lot of Spring MVC internal classes. A coworker reported that nested exceptions were losing their message when reported to our log aggregator. When I looked into it, it seems that "caused by" messages only include the exception class, not the message. This PR fixes that issue by including the cause message in the same way that Java's native exception printing does (capitalized "Caused by" as well as including the message).